### PR TITLE
Move shared NBXX notebook frontmatter into _quarto.yml

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -69,6 +69,19 @@ website:
 
 execute:
   freeze: auto
+  echo: false                        # suppresses code echo by default
+  warning: false                     # suppresses warnings even when echo is off
+  message: false                     # suppresses package load messages (library() etc.)
+
+knitr:
+  opts_chunk:
+    dpi: 300                         # belt-and-suspenders for knitr devices
+    dev: "ragg_png"                  # use ragg for better font rendering
+
+filters:
+  - flextable-qmd                    # needed, or the flextables render crazy
+  - at: post-render
+    path: _extensions/flextable-qmd/unwrap-float.lua
 
 format:
   html:

--- a/docs/NBXX-Outliers.qmd
+++ b/docs/NBXX-Outliers.qmd
@@ -13,20 +13,7 @@ format:
     link-bibliography: true
 
 execute:
-  echo: false
-  warning: false                     # suppresses warnings even when echo is off
-  message: false                     # suppresses package load messages (library() etc.)
   error: false                       # prevents errors from stopping the render
-
-knitr:
-  opts_chunk:
-    dpi: 300                         # belt-and-suspenders for knitr devices
-    dev: "ragg_png"                  # use ragg for better font rendering
-
-filters:
-  - flextable-qmd                    # needed, or the flextables render crazy 
-  - at: post-render
-    path: ../_extensions/flextable-qmd/unwrap-float.lua
 ---
 
 Some of our datasets include a lot of outliers. For example, let's take our fish data for *Gadus morhua* (excluding any measurements in dry weight for the sake of argument, and using liver measurements because they're the most data-rich).

--- a/docs/NBXX-REACH.qmd
+++ b/docs/NBXX-REACH.qmd
@@ -1,10 +1,6 @@
 ---
 title: "Copper REACH Data for Norway"
-execute:
-  output: true
-  echo: false
-  warning: false
-format: 
+format:
   html: default 
   docx: 
     fig-width: 8

--- a/docs/NBXX-algae.qmd
+++ b/docs/NBXX-algae.qmd
@@ -1,10 +1,6 @@
 ---
 title: "Algae"
-execute:
-  output: true
-  echo: false
-  warning: false
-format: 
+format:
   html: 
     fig-width: 16
     fig-height: 20

--- a/docs/NBXX-fish.qmd
+++ b/docs/NBXX-fish.qmd
@@ -13,20 +13,7 @@ format:
     link-bibliography: true
 
 execute:
-  echo: false
-  warning: false                     # suppresses warnings even when echo is off
-  message: false                     # suppresses package load messages (library() etc.)
   error: false                       # prevents errors from stopping the render
-
-knitr:
-  opts_chunk:
-    dpi: 300                         # belt-and-suspenders for knitr devices
-    dev: "ragg_png"                  # use ragg for better font rendering
-
-filters:
-  - flextable-qmd                    # needed, or the flextables render crazy 
-  - at: post-render
-    path: ../_extensions/flextable-qmd/unwrap-float.lua
 ---
 
 ```{r}

--- a/docs/NBXX-norske-utslipp.qmd
+++ b/docs/NBXX-norske-utslipp.qmd
@@ -1,9 +1,6 @@
 ---
 title: "Copper Emissions Data for Norway"
-execute:
-  output: true
-  echo: false
-format: 
+format:
   html: default
   docx: 
     fig-width: 8

--- a/docs/NBXX-reparfjorden.qmd
+++ b/docs/NBXX-reparfjorden.qmd
@@ -1,6 +1,5 @@
 ---
 title: "Notebook XX - Repparfjorden Case Study"
-author: "Sam Welch"
 date: last-modified
 lightbox: true
 ---


### PR DESCRIPTION
i.e. Claude, please remove the entirely superfluous frontmatter block you repeated 20 times. It's my own fault, I know.

> ## Summary
> - The NBXX-* distribution notebooks (Outliers, REACH, algae, fish, norske-utslipp, reparfjorden) repeated near-identical frontmatter for `execute` suppression, knitr chunk defaults, and the flextable-qmd filter chain
> - Hoisted the shared settings into `_quarto.yml`'s project-wide `execute`/`knitr`/`filters` config, and dropped the duplicated copies from each notebook
> - Left in place whatever was genuinely per-notebook: title, fig-width/height overrides, docx-specific settings, and each file's own `execute: error: false` where present
> - Also dropped the one exact duplicate found (`author: "Sam Welch"` in NBXX-reparfjorden.qmd, already covered by the project's global author list)
> 
> ## Test plan
> - [ ] Render the site (or at least a couple of the NBXX notebooks) and confirm output is unchanged from before